### PR TITLE
Fix version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "netzmacht/contao-toolkit": "^3.7",
     "netzmacht/html": "^2.0.2",
     "symfony/config": "^4.4 || ^5.4",
-    "symfony/dependency-injection": "4.4 || ^5.4",
+    "symfony/dependency-injection": "^4.4 || ^5.4",
     "symfony/http-kernel": "^4.4 || ^5.4"
   },
   "require-dev": {


### PR DESCRIPTION
`4.4` should probably be `^4.4`, shouldn't it?

With this change I removed an issue when updating a Contao 4.9 Installation that would end up in `"Class Doctrine\Common\Cache\ArrayCache does not exist"`.